### PR TITLE
Add basic color-coded table demo

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,17 @@
-from flask import Flask
+from flask import Flask, jsonify, send_from_directory
+from color_logic_live import sample_games
+import os
+
 app = Flask(__name__)
+
 @app.route('/')
-def home():
-    return 'BETBOX is running!'
+def index():
+    return send_from_directory('.', 'index.html')
+
+@app.route('/games')
+def games():
+    return jsonify(sample_games())
+
 if __name__ == '__main__':
-    app.run(debug=True)
+    port = int(os.environ.get('PORT', 5000))
+    app.run(debug=True, port=port)

--- a/color_logic_live.py
+++ b/color_logic_live.py
@@ -1,0 +1,21 @@
+def color_code(open_line, live_line):
+    """Return color string based on difference between opening and live line."""
+    diff = live_line - open_line
+    if diff >= 10:
+        return 'blue'
+    elif diff >= 7:
+        return 'green'
+    else:
+        return 'red'
+
+
+def sample_games():
+    """Return sample games with lines and color codes."""
+    games = [
+        {"team": "Team A vs Team B", "open": 100, "live": 112},
+        {"team": "Team C vs Team D", "open": 95, "live": 102},
+        {"team": "Team E vs Team F", "open": 110, "live": 108},
+    ]
+    for g in games:
+        g["color"] = color_code(g["open"], g["live"])
+    return games

--- a/index.html
+++ b/index.html
@@ -3,9 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <title>BETBOX</title>
+  <style>
+    table { border-collapse: collapse; width: 100%; }
+    th, td { padding: 8px; text-align: center; border: 1px solid #ddd; }
+    .red { background-color: #ffcccc; }
+    .green { background-color: #ccffcc; }
+    .blue { background-color: #ccccff; }
+  </style>
 </head>
 <body>
   <h1>ברוך הבא ל-BETBOX</h1>
+  <table id="games-table">
+    <thead>
+      <tr><th>משחק</th><th>שורת פתיחה</th><th>שורת לייב</th><th>סימון</th></tr>
+    </thead>
+    <tbody></tbody>
+  </table>
   <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,3 +1,13 @@
-document.addEventListener('DOMContentLoaded', function() {
-    console.log('main.js loaded');
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('/games')
+    .then(response => response.json())
+    .then(games => {
+      const tbody = document.querySelector('#games-table tbody');
+      games.forEach(g => {
+        const row = document.createElement('tr');
+        row.classList.add(g.color);
+        row.innerHTML = `<td>${g.team}</td><td>${g.open}</td><td>${g.live}</td><td>${g.color}</td>`;
+        tbody.appendChild(row);
+      });
+    });
 });


### PR DESCRIPTION
## Summary
- add `color_logic_live.py` with simple diff-to-color logic and sample data
- serve `index.html` via Flask and provide `/games` endpoint
- display games in an HTML table with red/green/blue rows
- populate table from `/games` using `main.js`

## Testing
- `python -m py_compile app.py color_logic_live.py`
- `pip install flask` *(fails: Tunnel connection failed)*
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688624618c3c83319d03288503909efd